### PR TITLE
fix to work on Windows

### DIFF
--- a/perf/_runner.py
+++ b/perf/_runner.py
@@ -694,7 +694,7 @@ class Runner:
 
             if exitcode:
                 raise RuntimeError("%s failed with exit code %s"
-                                % (cmd[0], exitcode))
+                                   % (cmd[0], exitcode))
 
             with open(tmp_file, "r", encoding="utf8") as rfile:
                 bench_json = rfile.read()

--- a/perf/_runner.py
+++ b/perf/_runner.py
@@ -698,7 +698,7 @@ class Runner:
 
             with open(tmp_file, "r", encoding="utf8") as rfile:
                 bench_json = rfile.read()
-        except:
+        finally:
             try:
                 os.remove(tmp_file)
             except OSError:

--- a/perf/_runner.py
+++ b/perf/_runner.py
@@ -701,7 +701,7 @@ class Runner:
         except:
             try:
                 os.remove(tmp_file)
-            except FileNotFoundError:
+            except OSError:
                 pass
 
         return _load_suite_from_pipe(bench_json)

--- a/perf/_runner.py
+++ b/perf/_runner.py
@@ -607,17 +607,21 @@ class Runner:
                             func_metadata=metadata,
                             globals=globals)
 
-    def _worker_cmd(self, calibrate, wpipe):
+    def _worker_cmd(self, calibrate, wpipe, output=None):
         args = self.args
 
         cmd = [args.python]
         cmd.extend(self._program_args)
-        cmd.extend(('--worker', '--pipe', str(wpipe),
+        cmd.extend(('--worker',
                     '--worker-task=%s' % self._worker_task,
                     '--samples', str(args.samples),
                     '--warmups', str(args.warmups),
                     '--loops', str(args.loops),
                     '--min-time', str(args.min_time)))
+        if wpipe:
+            cmd.extend(('--pipe', str(wpipe)))
+        if output:
+            cmd.extend(('--output', output))
         if calibrate:
             cmd.append('--calibrate')
         if args.verbose:
@@ -635,6 +639,12 @@ class Runner:
         return cmd
 
     def _spawn_worker(self, calibrate=False):
+        if MS_WINDOWS:
+            return self._spawn_worker_windows(calibrate)
+        else:
+            return self._spawn_worker_posix(calibrate)
+
+    def _spawn_worker_posix(self, calibrate=False):
         rpipe, wpipe = pipe_cloexec()
         if six.PY3:
             rfile = open(rpipe, "r", encoding="utf8")
@@ -663,6 +673,36 @@ class Runner:
         if exitcode:
             raise RuntimeError("%s failed with exit code %s"
                                % (cmd[0], exitcode))
+
+        return _load_suite_from_pipe(bench_json)
+
+    def _spawn_worker_windows(self, calibrate=False):
+        import tempfile
+        wpipe, tmp_file = tempfile.mkstemp()
+        os.close(wpipe)
+        os.remove(tmp_file)  # remove for subprocess to create
+
+        cmd = self._worker_cmd(calibrate, None, output=tmp_file)
+        env = create_environ(self.args.inherit_environ,
+                             self.args.locale)
+
+        try:
+            proc = subprocess.Popen(cmd, env=env)
+
+            with popen_killer(proc):
+                exitcode = proc.wait()
+
+            if exitcode:
+                raise RuntimeError("%s failed with exit code %s"
+                                % (cmd[0], exitcode))
+
+            with open(tmp_file, "r", encoding="utf8") as rfile:
+                bench_json = rfile.read()
+        except:
+            try:
+                os.remove(tmp_file)
+            except FileNotFoundError:
+                pass
 
         return _load_suite_from_pipe(bench_json)
 


### PR DESCRIPTION
I found out that perf module does not work on Windows platform.  I created a fix so would you please review it and, if it's acceptable, merge to your code?

On Windows it fails subprocess.Popen() because _pass_fds_ is no supported on Windows.

    C:\Users\Tsutomu\dev\perf>python -m perf timeit --loop 1000 pass
    Error when running timeit benchmark:
    
    Statement:
    'pass'
    
    Traceback (most recent call last):
      File "C:\Users\Tsutomu\dev\perf\perf\_timeit.py", line 203, in bench_timeit
        runner.bench_sample_func(name, timer.sample_func, **kwargs)
      File "C:\Users\Tsutomu\dev\perf\perf\_runner.py", line 541, in bench_sample_func
        return self._main(name, sample_func, inner_loops, metadata)
      File "C:\Users\Tsutomu\dev\perf\perf\_runner.py", line 508, in _main
        bench = self._master()
      File "C:\Users\Tsutomu\dev\perf\perf\_runner.py", line 771, in _master
        bench = self._spawn_workers()
      File "C:\Users\Tsutomu\dev\perf\perf\_runner.py", line 728, in _spawn_workers
        suite = self._spawn_worker(calibrate)
      File "C:\Users\Tsutomu\dev\perf\perf\_runner.py", line 653, in _spawn_worker
        proc = subprocess.Popen(cmd, env=env, **kw)
      File "c:\Users\Tsutomu\tools\Python3\lib\subprocess.py", line 947, in __init__
        restore_signals, start_new_session)
      File "c:\Users\Tsutomu\tools\Python3\lib\subprocess.py", line 1195, in _execute_child
        assert not pass_fds, "pass_fds not supported on Windows."
    AssertionError: pass_fds not supported on Windows.
    
    C:\Users\Tsutomu\dev\perf>

Actually, pipe between a process and its child process is not supported by subprocess on Windows.

https://docs.python.org/3.5/library/os.html#inheritance-of-file-descriptors

`On Windows, (...) _all file descriptors except standard streams are closed_, and inheritable handles are only inherited if the close_fds parameter is False.`

I created a patch to use a temporary file.  It uses --output option to dump() the benchmark.

I tested on Python 3.5.2 on Windows 10.

    C:\Users\Tsutomu\dev\perf>python -m perf timeit --loop 1000 pass
    timeit: Median +- std dev: 9.84 ns +- 0.25 ns
    .timeit: Median +- std dev: 9.41 ns +- 0.25 ns
    .timeit: Median +- std dev: 9.84 ns +- 0.25 ns
    (...)
    .timeit: Median +- std dev: 9.41 ns +- 0.25 ns
    .
    WARNING: the benchmark may be unstable, the shortest raw sample only took 9.41 us
    Try to rerun the benchmark with more loops or increase --min-time
    
    Median +- std dev: 9.84 ns +- 0.72 ns

    C:\Users\Tsutomu\dev\perf>

I'd appreciate any comments for improvement or refinement.