### PR TITLE
fix for Windows with pipes

### DIFF
--- a/perf/_runner.py
+++ b/perf/_runner.py
@@ -28,6 +28,7 @@ if MS_WINDOWS:
     import msvcrt
     from perf._utils import HandleOfPipe
 
+
 class Runner:
     # Default parameters are chosen to have approximatively a run of 0.5 second
     # and so a total duration of 5 seconds by default
@@ -648,7 +649,6 @@ class Runner:
             try:
                 if MS_WINDOWS:
                     whandle = HandleOfPipe(wpipe)
-
                     cmd = self._worker_cmd(calibrate, whandle.handle)
                 else:
                     cmd = self._worker_cmd(calibrate, wpipe)

--- a/perf/_runner.py
+++ b/perf/_runner.py
@@ -24,6 +24,8 @@ try:
 except ImportError:
     psutil = None
 
+if MS_WINDOWS:
+    import msvcrt
 
 class Runner:
     # Default parameters are chosen to have approximatively a run of 0.5 second
@@ -643,13 +645,20 @@ class Runner:
 
         with rfile:
             try:
-                cmd = self._worker_cmd(calibrate, wpipe)
+                if MS_WINDOWS:
+                    whandle = msvcrt.get_osfhandle(wpipe)
+                    os.set_handle_inheritable(whandle, True)
+                    cmd = self._worker_cmd(calibrate, whandle)
+                else:
+                    cmd = self._worker_cmd(calibrate, wpipe)
                 env = create_environ(self.args.inherit_environ,
                                      self.args.locale)
 
                 kw = {}
-                if sys.version_info >= (3, 2):
+                if sys.version_info >= (3, 2) and not MS_WINDOWS:
                     kw['pass_fds'] = [wpipe]
+                if MS_WINDOWS:
+                    kw['close_fds'] = False
                 proc = subprocess.Popen(cmd, env=env, **kw)
             finally:
                 os.close(wpipe)
@@ -674,7 +683,11 @@ class Runner:
             checks = False
 
         if args.pipe is not None:
-            fd = args.pipe
+            if MS_WINDOWS:
+                handle = args.pipe
+                fd = msvcrt.open_osfhandle(handle, os.O_WRONLY)
+            else:
+                fd = args.pipe
             if six.PY3:
                 wpipe = open(fd, "w", encoding="utf8")
             else:


### PR DESCRIPTION
This is new PR to replace #17 

By request from @haypo  to use pipes, file handle instead of fd is passed to the child process.  Would you please review again?

Tested on:

- Windows 10 Professional 64bit
   - Python 2.7.11
   - Python 3.5.2
- Ubuntu 14.04.1
   - Python 2.7.6
   - Python 3.4.3

There is a difference in creating a inheritable file handle between Python 2 and 3.  I referred this article https://digitalenginesoftware.com/blog/archives/47-Passing-pipes-to-subprocesses-in-Python-in-Windows.html

I created HandleOfPipe class to wrap the difference.  The class is for Windows only.  It should be possible to also put POSIX pipe into the class, but I thought it's too much.