### PR TITLE
Fix Windows 32bit issue

### DIFF
--- a/perf/_utils.py
+++ b/perf/_utils.py
@@ -362,7 +362,7 @@ if MS_WINDOWS:
         from ctypes import WinError
 
         HANDLE_FLAG_INHERIT = 1
-        SetHandleInformation = ctypes.cdll.kernel32.SetHandleInformation
+        SetHandleInformation = ctypes.windll.kernel32.SetHandleInformation
 
         def set_handle_inheritable(handle, inheritable):
             flags = HANDLE_FLAG_INHERIT if inheritable else 0


### PR DESCRIPTION
perf 0.9.3 again runs on Windows but it fails with 32bit runtime of Python 2.7 on 64bit platform.

Windows 10 64bit + Python 3.6 32bit -> success
Windows 10 64bit + Python 3.6 64bit -> success
Windows 10 64bit + Python 2.7.11 64bit -> success
Windows 10 64bit + Python 2.7.11 **32**bit -> **fail**

    C:\Python27>Scripts\pip install perf
    ...
    
    C:\Python27>python -m perf timeit --loop 1000 pass
    Error when running timeit benchmark:
    
    Statement:
    'pass'
    
    Traceback (most recent call last):
      File "C:\Python27\lib\site-packages\perf\_timeit.py", line 203, in bench_timeit
        runner.bench_sample_func(name, timer.sample_func, **kwargs)
      File "C:\Python27\lib\site-packages\perf\_runner.py", line 541, in bench_sample_func
        return self._main(name, sample_func, inner_loops, metadata)
      File "C:\Python27\lib\site-packages\perf\_runner.py", line 508, in _main
        bench = self._master()
      File "C:\Python27\lib\site-packages\perf\_runner.py", line 768, in _master
        bench = self._spawn_workers()
      File "C:\Python27\lib\site-packages\perf\_runner.py", line 724, in _spawn_workers
        suite = self._spawn_worker(calibrate)
      File "C:\Python27\lib\site-packages\perf\_runner.py", line 644, in _spawn_worker
        warg = wpipe.to_subprocess()
      File "C:\Python27\lib\site-packages\perf\_utils.py", line 432, in to_subprocess
        set_handle_inheritable(self._handle, True)
      File "C:\Python27\lib\site-packages\perf\_utils.py", line 370, in set_handle_inheritable
        ok = SetHandleInformation(handle, HANDLE_FLAG_INHERIT, flags)
    ValueError: Procedure called with not enough arguments (12 bytes missing) or wrong calling convention

This is a calling convention issue.  In _utils.py, ctypes.**cdll**.kernel32 should be ctypes.**windll**.kernel32.  I confirmed it works on Python 2.7 32bit and 64bit.